### PR TITLE
Jet safari schedule, prizes, punches fix

### DIFF
--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -878,7 +878,6 @@ this is so hamburger menu does not show for safari*/
 		border-spacing: 0;
 		/* border-radius: 100%; */
 		box-shadow: var(--shadow);
-		
 	}
 	.rounded-table, .schedule-table.no-color {
 		background: #0000;
@@ -1034,9 +1033,10 @@ this is so hamburger menu does not show for safari*/
 	#punches td {
 		padding: var(--pad-small);
 		background: var(--orange-glass-less);
-		&:not(:first-child):not(:last-child) {
-			width: 48px;
-		}
+		
+	}
+	#punches td:not(:first-child):not(:last-child) {
+		width: 48px;
 	}
 	#punches .title {
 		padding-left: var(--pad-big);
@@ -1135,6 +1135,19 @@ this is so hamburger menu does not show for safari*/
 			background-color: var(--dark-peach);
 			margin: 0px;
 		}
+
+		/*punches */
+		#punches td{
+			padding: 0.1em;
+		}
+		#punches .title{
+			padding-left: var(--pad-small);
+		}
+		#punches .punch{
+			width: 30px;
+			height: 30px;
+		}
+
     }
 }
 /*End Safari Filter*/

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -190,7 +190,7 @@ input[type="submit"] {
 }
 
 /* Styling for the red "rounded-row" tables. */
-.rounded-table, .schedule-table {
+.rounded-table, .schedule-table { /*whole table*/
 	width: 100%;
 	color: var(--faded-white-glass);
 	background: var(--blood-glass);
@@ -202,21 +202,24 @@ input[type="submit"] {
 		box-shadow: none;
 	}
 	tbody {
-		&:first-child th {
+		&:first-child th { /*top dark bar*/
 			padding: var(--pad-weeny);
 			font-size: var(--font-slight);
 			background: var(--maroon);
 		}
-		tr {
-			th:first-child, td:first-child {
+		tr { 
+			th:first-child, td:first-child { /*left side (prize)*/
+				border: red solid 3px;
 				border-top-left-radius: var(--radius);
 				border-bottom-left-radius: var(--radius);
 			}
-			th:last-child, td:last-child {
+			th:last-child, td:last-child { /*green stuff on right*/
+				border: green solid 3px;
 				border-top-right-radius: var(--radius);
 				border-bottom-right-radius: var(--radius);
 			}
-			td {
+			td {  /*middle stuff*/
+				border: blue solid 3px;
 				background: var(--blood);
 				font-size: var(--font-medium);
 				text-align: center;
@@ -296,7 +299,7 @@ input[type="submit"] {
 	}
 }
 .claim-button{
-	min-width: 10em
+	min-width: 10em;
 }
 
 
@@ -876,7 +879,15 @@ this is so hamburger menu does not show for safari*/
 		color: var(--faded-white-glass);
 		background: var(--blood-glass);
 		border-spacing: 0;
-		/* border-radius: 100%; */
+		border-radius: var(--radius);
+		box-shadow: var(--shadow);
+	}
+	#prizes-content{
+		width: 100%;
+		color: var(--faded-white-glass);
+		background: var(--blood);
+		border-spacing: 0;
+		border-radius: var(--radius);
 		box-shadow: var(--shadow);
 	}
 	.rounded-table, .schedule-table.no-color {
@@ -888,6 +899,12 @@ this is so hamburger menu does not show for safari*/
 		font-size: var(--font-slight);
 		background: var(--maroon);
 	}
+	#prizes-content tr:first-child{
+		padding: var(--pad-weeny);
+		font-size: var(--font-slight);
+		background: var(--maroon);
+	}
+
 	.rounded-table, .schedule-table tbody tr th:first-child, td:first-child {
 		border-top-left-radius: var(--radius);
 		border-bottom-left-radius: var(--radius);
@@ -896,14 +913,45 @@ this is so hamburger menu does not show for safari*/
 		border-top-right-radius: var(--radius);
 		border-bottom-right-radius: var(--radius);
 	}
+
+	#prizes-content tr th:first-child {
+		border-top-left-radius: var(--radius);
+		border-bottom-left-radius: var(--radius);
+	}
+	#prizes-content tr th:last-child {
+		border-top-right-radius: var(--radius);
+		border-bottom-right-radius: var(--radius);
+	}
+	#prizes-content tr td:first-child {
+		border-top-left-radius: var(--radius);
+		border-bottom-left-radius: var(--radius);
+	}
+	#prizes-content tr td:last-child {
+		border-top-right-radius: var(--radius);
+		border-bottom-right-radius: var(--radius);
+	}
+	
 	.rounded-table, .schedule-table tbody tr td {
 		background: var(--blood);
+		font-size: var(--font-medium);
+		text-align: center;
+	}
+	#prizes {
+		background: var(--blood-glass);
 		font-size: var(--font-medium);
 		text-align: center;
 	}
 	.rounded-table, .schedule-table .table-spacer {
 		height: var(--pad-teeny);
 	}
+
+
+
+
+
+
+
+
 	/* announcements */
 	.announcement, .log {
 		margin: var(--pad-tiny);
@@ -1092,6 +1140,50 @@ this is so hamburger menu does not show for safari*/
 		}
 	}
 
+	/*prizes in supports */
+
+	#balance {
+		margin-top: var(--pad-medium);
+		text-align: right;
+		color: var(--faded-white-glass);
+	}
+	#balance #points {
+		padding: 0 2em;
+	}
+	
+	#prizes td {
+		padding: var(--pad-tiny) 0;
+	}
+	#prizes td .claim {
+		padding: var(--pad-tiny) var(--pad-small);
+		margin: var(--pad-small) 0;
+		color: var(--faded-white-glass);
+		font-size: var(--font-medium);
+		text-align: center;
+		background: var(--blue-purple);
+		border: none;
+		border-radius: var(--radius);
+	}
+	#prizes td .claim:hover {
+		cursor: pointer;
+	}
+	#prizes td .claim .claimed {
+		background: gray;
+		
+	}
+	#prizes td .claim .retrieved:hover {
+		cursor: default;
+	}
+	#prizes td .claim .retrieved {
+		background: gray;
+	}
+	#prizes td .claim .retrieved:hover {
+		cursor: default;
+	}
+	.claim-button{
+		min-width: 10em;
+	}
+
     @media screen and (min-width:300px) and (max-width:880px)  {
         
 		.link{
@@ -1147,7 +1239,33 @@ this is so hamburger menu does not show for safari*/
 			width: 30px;
 			height: 30px;
 		}
-
+		/* prizes */
+		.prizes-container{
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			flex-direction: column;
+		}
+		.claim{
+			font-size: small;
+			padding: 1em;
+		}
+		.claim-button{
+			min-width: 3em;
+			font-size:small;
+			margin: 1em;
+		}
+		#prizes tr{
+			align-self: center;
+		}
+		#prizes td{
+			font-size: small;
+			margin: var(--pad-tiny) 0;
+		}
+		.claimed, .retrieved {
+			margin: 10px !important;
+		}
+		/*End prizes*/
     }
 }
 /*End Safari Filter*/

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -876,7 +876,7 @@ this is so hamburger menu does not show for safari*/
 		color: var(--faded-white-glass);
 		background: var(--blood-glass);
 		border-spacing: 0;
-		border-radius: var(--radius);
+		/* border-radius: 100%; */
 		box-shadow: var(--shadow);
 		
 	}
@@ -902,7 +902,7 @@ this is so hamburger menu does not show for safari*/
 		font-size: var(--font-medium);
 		text-align: center;
 	}
-	.rounded-table, .schedule-table.table-spacer {
+	.rounded-table, .schedule-table .table-spacer {
 		height: var(--pad-teeny);
 	}
 	/* announcements */
@@ -985,24 +985,37 @@ this is so hamburger menu does not show for safari*/
 
 	/* #schedule  */
 	#schedule .map img {
+		margin: 0px 0px 0px var(--pad-tiny);
 		padding: var(--pad-small) 0;
 		max-width: 200px;
 	}
-	#schedule.info, .description {
+	#schedule .info, .description {
 		padding-top: var(--pad-small);
 		vertical-align: top;
 	}
-	#schedule.info, .description p {
+	#schedule .info, .description p {
 		margin-bottom: 0;
 		margin-top: 0;
 		padding-left: var(--pad-small);
 		text-align: left;
 	}
-	#schedule.info, .description.time {
+	#schedule .info, .description .time {
+		/* margin: 0px var(--pad-tiny) 0px 0px; */
 		padding: var(--pad-tiny) var(--pad-small);
 		background: var(--maroon);
 		border-radius: var(--radius);
 	}
+	#schedule td.info{
+		background: var(--blood);
+		border-radius: 0%;
+	}
+	#schedule .event-current td {
+		background-color: var(--dark-peach);
+	}
+	#schedule .event-current .time {
+		background-color: var(--peach);
+	}
+	
 
 	/*punches */
 	#punches {
@@ -1110,6 +1123,17 @@ this is so hamburger menu does not show for safari*/
 		}
 		#navbar .link:first-child{
 			margin-left: calc(var(--pad-tiny) + 20px);
+		}
+
+		/* schedule in media in supports */
+		#schedule td.info{
+			background: var(--blood);
+			border-radius: 0%;
+			margin: 0px;
+		}
+		#schedule .event-current td.info {
+			background-color: var(--dark-peach);
+			margin: 0px;
 		}
     }
 }

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -209,17 +209,17 @@ input[type="submit"] {
 		}
 		tr { 
 			th:first-child, td:first-child { /*left side (prize)*/
-				border: red solid 3px;
+				
 				border-top-left-radius: var(--radius);
 				border-bottom-left-radius: var(--radius);
 			}
 			th:last-child, td:last-child { /*green stuff on right*/
-				border: green solid 3px;
+			
 				border-top-right-radius: var(--radius);
 				border-bottom-right-radius: var(--radius);
 			}
 			td {  /*middle stuff*/
-				border: blue solid 3px;
+
 				background: var(--blood);
 				font-size: var(--font-medium);
 				text-align: center;


### PR DESCRIPTION

safari fixes for punches, schedule pages look identical to chrome

safari prizes look almost idnetical,  the claims button is touhcing quantity number not sure how to fix. but it does not look atrocious

checked on iphone safari.  and responsive on chrome

![punches](https://github.com/HackMerced/HackMerced-IX-Live/assets/110573869/76a30da5-3926-49bd-bf8a-c5c8cf8a9f5a)
![prizes](https://github.com/HackMerced/HackMerced-IX-Live/assets/110573869/db3f741e-20b4-43bd-85b4-05c2180bf23a)
![schueld 2](https://github.com/HackMerced/HackMerced-IX-Live/assets/110573869/ecd95666-c8fe-4e32-8eca-ee2a2819626e)
![schedule 1](https://github.com/HackMerced/HackMerced-IX-Live/assets/110573869/ff80f153-f3be-4602-9a2c-f4ef0d078cdb)

